### PR TITLE
Feat: Point rviz 2D Goal Pose tool at nav2 /goal_pose

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -23,6 +23,18 @@ Panels:
 Visualization Manager:
   Class: ""
   Displays:
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: Nav2 Route Graph
+      Namespaces:
+        {}
+      Topic:
+        Depth: 5
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /route_graph_viz
+      Value: true
     - Class: rviz_common/Group
       Displays:
         - Class: rviz_default_plugins/TF

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -3726,7 +3726,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /planning/mission_planning/goal
+        Value: /goal_pose
     - Class: tier4_adapi_rviz_plugins::RouteTool
       Topic:
         Depth: 5


### PR DESCRIPTION
The autoware mission planner is not used; goals go to nav2's bt_navigator, which subscribes to /goal_pose directly.


